### PR TITLE
hook grub-install and  make it grub 2.06 compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.zst
+*.gz
+src
+pkg

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -13,6 +13,7 @@ package() {
   cd "$srcdir/$pkgname-$pkgver"
   install -Dm755 cryptboot "$pkgdir/usr/bin/cryptboot"
   install -Dm755 cryptboot-efikeys "$pkgdir/usr/bin/cryptboot-efikeys"
+  install -Dm755 grub-install "$pkgdir/usr/local/bin/grub-install"
   install -Dm644 cryptboot.conf "$pkgdir/etc/cryptboot.conf"
 }
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Requirements
 - efibootmgr
 - grub (grub-efi on Debian based distributions)
 
-On Arch Linux, use `sudo pacman -S efitools sbsigntools efibootmgr`.
+On Arch Linux, there is a [AUR package cryptboot](https://aur.archlinux.org/packages/cryptboot).
 
 Installation
 ------------

--- a/contrib/PKGBUILD
+++ b/contrib/PKGBUILD
@@ -1,13 +1,15 @@
+# Maintainer: kmille <github@androidloves.me>
 # Maintainer: Michal Krenek (Mikos) <m.krenek@gmail.com>
 pkgname=cryptboot
-pkgver=1.1.0
+pkgver=1.2.0
 pkgrel=1
 pkgdesc="Encrypted boot partition manager with UEFI Secure Boot support"
 arch=('any')
 url="https://github.com/xmikos/cryptboot"
 license=('GPL3')
 depends=('cryptsetup' 'grub' 'efibootmgr' 'efitools' 'sbsigntools')
-source=(https://github.com/xmikos/cryptboot/archive/v$pkgver.tar.gz)
+source=(https://github.com/kmille/cryptboot/archive/refs/tags/v$pkgver.tar.gz)
+sha256sums=('53863e54be9bcd6bd47ad05b5c0afbcaae139d590106ef098da275adb86f46e6')
 
 package() {
   cd "$srcdir/$pkgname-$pkgver"

--- a/cryptboot
+++ b/cryptboot
@@ -1,35 +1,5 @@
 #!/bin/bash
 
-# Parse cryptsetup device from /etc/crypttab
-find_crypt_dev() {
-  crypt_name="$1"
-  while read -r line || [[ -n "$line" ]]; do
-    line="$(echo "$line" | sed 's/\s\+/\t/g')"
-    line_crypt_name="$(echo "$line" | cut -f 1)"
-    line_crypt_dev="$(echo "$line" | cut -f 2)"
-    if [[ "$line_crypt_name" = "$crypt_name" ]]; then
-      echo "$line_crypt_dev"
-      return 0
-    fi
-  done < /etc/crypttab
-  return 1
-}
-
-# Remove EFI boot manager entries by label
-remove_efi_boot_entry() {
-  entry_label="$1"
-  efi_boot_entries="$(efibootmgr)"
-  while read -r line || [[ -n "$line" ]]; do
-    if [[ $line =~ ^Boot([0-9A-F]+)\*?[[:blank:]]+(.+)$ ]]; then
-      line_entry_num="${BASH_REMATCH[1]}"
-      line_entry_label="${BASH_REMATCH[2]}"
-      if [[ "$entry_label" = "$line_entry_label" ]]; then
-        efibootmgr -q -b "$line_entry_num" -B
-      fi
-    fi
-  done <<< "$efi_boot_entries"
-}
-
 # Check if user is root
 if [[ $UID -ne 0 ]]; then
   echo "Permission denied (you must be root)"
@@ -56,13 +26,6 @@ fi
 
 # Get path to cryptboot-efikeys executable
 EFIKEYS_BIN="$(which cryptboot-efikeys 2>/dev/null)" || EFIKEYS_BIN="$SRCDIR/cryptboot-efikeys"
-
-# Check if cryptsetup boot device exists
-BOOT_CRYPT_DEV="$(find_crypt_dev "$BOOT_CRYPT_NAME")"
-if [[ -z "$BOOT_CRYPT_DEV" ]]; then
-  echo "Couldn't find cryptsetup device name '$BOOT_CRYPT_NAME', check your /etc/crypttab"
-  exit 1
-fi
 
 # Check if /boot mountpoint exists
 if ! findmnt -sn "$BOOT_DIR" &>/dev/null; then

--- a/cryptboot
+++ b/cryptboot
@@ -76,7 +76,7 @@ case "$1" in
     grub-mkconfig -o "$BOOT_DIR/grub/grub.cfg"
 
     echo "Reinstalling GRUB to EFI System partition..."
-    grub-install --target=x86_64-efi --boot-directory="$BOOT_DIR" --efi-directory="$EFI_DIR" --bootloader-id="$EFI_ID_GRUB" --modules="tpm" --disable-shim-lock
+    /usr/bin/grub-install --target=x86_64-efi --boot-directory="$BOOT_DIR" --efi-directory="$EFI_DIR" --bootloader-id="$EFI_ID_GRUB" --modules="tpm" --disable-shim-lock
 
     echo "Signing GRUB with UEFI Secure Boot keys..."
     "$EFIKEYS_BIN" sign "$EFI_DIR/$EFI_PATH_GRUB"

--- a/cryptboot
+++ b/cryptboot
@@ -27,6 +27,20 @@ fi
 # Get path to cryptboot-efikeys executable
 EFIKEYS_BIN="$(which cryptboot-efikeys 2>/dev/null)" || EFIKEYS_BIN="$SRCDIR/cryptboot-efikeys"
 
+find_crypt_dev() {
+  crypt_name="$1"
+  while read -r line || [[ -n "$line" ]]; do
+    line="$(echo "$line" | sed 's/\s\+/\t/g')"
+    line_crypt_name="$(echo "$line" | cut -f 1)"
+    line_crypt_dev="$(echo "$line" | cut -f 2)"
+    if [[ "$line_crypt_name" = "$crypt_name" ]]; then
+      echo "$line_crypt_dev"
+      return 0
+    fi
+  done < /etc/crypttab
+}
+
+
 # Check if /boot mountpoint exists
 if ! findmnt -sn "$BOOT_DIR" &>/dev/null; then
   echo "Couldn't find boot partition mountpoint '$BOOT_DIR', check your /etc/fstab"
@@ -44,6 +58,12 @@ case "$1" in
   mount)
     if findmnt -n "$BOOT_DIR" &>/dev/null || findmnt -n "$EFI_DIR" &>/dev/null; then
       echo "Boot partition or EFI System partition already mounted, skipping mount..."
+      exit 1
+    fi
+
+    BOOT_CRYPT_DEV="$(find_crypt_dev "$BOOT_CRYPT_NAME")"
+    if [[ -z "$BOOT_CRYPT_DEV" ]]; then
+      echo "Couldn't find cryptsetup device name '$BOOT_CRYPT_NAME', check your /etc/crypttab"
       exit 1
     fi
 

--- a/cryptboot
+++ b/cryptboot
@@ -76,7 +76,7 @@ case "$1" in
     grub-mkconfig -o "$BOOT_DIR/grub/grub.cfg"
 
     echo "Reinstalling GRUB to EFI System partition..."
-    grub-install --target=x86_64-efi --boot-directory="$BOOT_DIR" --efi-directory="$EFI_DIR" --bootloader-id="$EFI_ID_GRUB"
+    grub-install --target=x86_64-efi --boot-directory="$BOOT_DIR" --efi-directory="$EFI_DIR" --bootloader-id="$EFI_ID_GRUB" --modules="tpm" --disable-shim-lock
 
     echo "Signing GRUB with UEFI Secure Boot keys..."
     "$EFIKEYS_BIN" sign "$EFI_DIR/$EFI_PATH_GRUB"

--- a/grub-install
+++ b/grub-install
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -eu
+
+# this will
+# 1) call grub-mkconfig
+# 2) call grub-install
+# 3) sign the bootloader
+cryptboot update-grub


### PR DESCRIPTION
There are two main improvements:
- hook `grub-install` to automatically sign the bootloader
- make it compatible with grub 2.06 

Please read the discussion in #7.